### PR TITLE
Add support for the source map attribute

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+# 0.2.0 - 2015-11-24
+
+- Add support for the `sourceMap` element attribute.
+
 # 0.1.0 - 2015-09-08
 
 - Initial release.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minim-parse-result",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Minim Parse Result Namespace",
   "main": "./lib/parse-result.js",
   "repository": {
@@ -23,7 +23,7 @@
   "devDependencies": {
     "chai": "^3.2.0",
     "coveralls": "^2.11.2",
-    "minim": "^0.11.0",
+    "minim": "^0.12.1",
     "peasant": "^0.5.2"
   },
   "author": "Apiary.io <support@apiary.io>",

--- a/src/parse-result.js
+++ b/src/parse-result.js
@@ -14,6 +14,26 @@ export function namespace(options) {
   const ArrayElement = minim.getElementClass('array');
   const StringElement = minim.getElementClass('string');
 
+  // First, modify the base and all currently registered elements to include
+  // the new `sourceMap` attribute, which is an unrefracted array of
+  // refracted source map elements.
+  minim.BaseElement = class SourceMappedBase extends minim.BaseElement {
+    constructor() {
+      super(...arguments);
+      this._attributeElementArrayKeys.push('sourceMap');
+    }
+  };
+
+  Object.keys(minim.elementMap).forEach((key) => {
+    const ElementClass = minim.elementMap[key];
+    minim.elementMap[key] = class SourceMapped extends ElementClass {
+      constructor() {
+        super(...arguments);
+        this._attributeElementArrayKeys.push('sourceMap');
+      }
+    };
+  });
+
   class ParseResult extends ArrayElement {
     constructor() {
       super(...arguments);

--- a/test/parse-result.js
+++ b/test/parse-result.js
@@ -11,10 +11,11 @@ import minimParseResult from '../src/parse-result';
 const namespace = minim.namespace()
   .use(minimParseResult);
 
+const Annotation = namespace.getElementClass('annotation');
 const Category = namespace.getElementClass('category');
 const ParseResult = namespace.getElementClass('parseResult');
-const Annotation = namespace.getElementClass('annotation');
 const SourceMap = namespace.getElementClass('sourceMap');
+const StringElement = namespace.getElementClass('string');
 
 chai.use((_chai, utils) => {
   /*
@@ -128,6 +129,52 @@ describe('Parse result namespace', () => {
 
     it('should have element name sourceMap', () => {
       expect(sourceMap.element).to.equal('sourceMap');
+    });
+  });
+
+  context('source maps', () => {
+    let element;
+    let sourceMaps;
+
+    beforeEach(() => {
+      element = (new StringElement()).fromCompactRefract([
+        'string', {}, {
+          sourceMap: [
+            ['sourceMap', {}, {}, [[1, 2]]],
+          ],
+        }, [],
+      ]);
+      sourceMaps = element.attributes.get('sourceMap');
+    });
+
+    it('should contain a sourceMap attribute with one item', () => {
+      expect(sourceMaps).to.exist;
+      expect(sourceMaps).to.have.length(1);
+    });
+
+    it('should have the source map location', () => {
+      expect(sourceMaps.first().toValue()).to.deep.equal([[1, 2]]);
+    });
+
+    it('should serialize with a sourceMap attribute', () => {
+      const expected = {
+        element: 'string',
+        meta: {},
+        attributes: {
+          sourceMap: [
+            {
+              element: 'sourceMap',
+              meta: {},
+              attributes: {},
+              content: [
+                [1, 2],
+              ],
+            },
+          ],
+        },
+        content: [],
+      };
+      expect(element.toRefract()).to.deep.equal(expected);
     });
   });
 });


### PR DESCRIPTION
This builds on https://github.com/refractproject/minim/pull/87 to provide the source map attribute to all elements.

cc @smizell 