### PR TITLE
Fix a bug caused by overwriting the base element

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+# 0.2.1 - 2015-11-24
+
+- Fix a bug that was caused by overwriting the base element. This is now accomplished in another way.
+
 # 0.2.0 - 2015-11-24
 
 - Add support for the `sourceMap` element attribute.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minim-parse-result",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Minim Parse Result Namespace",
   "main": "./lib/parse-result.js",
   "repository": {
@@ -23,7 +23,7 @@
   "devDependencies": {
     "chai": "^3.2.0",
     "coveralls": "^2.11.2",
-    "minim": "^0.12.1",
+    "minim": "^0.12.2",
     "peasant": "^0.5.2"
   },
   "author": "Apiary.io <support@apiary.io>",

--- a/src/parse-result.js
+++ b/src/parse-result.js
@@ -14,25 +14,10 @@ export function namespace(options) {
   const ArrayElement = minim.getElementClass('array');
   const StringElement = minim.getElementClass('string');
 
-  // First, modify the base and all currently registered elements to include
+  // First, modify the default list of special attributes to include
   // the new `sourceMap` attribute, which is an unrefracted array of
   // refracted source map elements.
-  minim.BaseElement = class SourceMappedBase extends minim.BaseElement {
-    constructor() {
-      super(...arguments);
-      this._attributeElementArrayKeys.push('sourceMap');
-    }
-  };
-
-  Object.keys(minim.elementMap).forEach((key) => {
-    const ElementClass = minim.elementMap[key];
-    minim.elementMap[key] = class SourceMapped extends ElementClass {
-      constructor() {
-        super(...arguments);
-        this._attributeElementArrayKeys.push('sourceMap');
-      }
-    };
-  });
+  minim._attributeElementArrayKeys.push('sourceMap');
 
   class ParseResult extends ArrayElement {
     constructor() {


### PR DESCRIPTION
This fixes the problem of overwriting the base element while still being able to let every element in the namespace have source maps.

cc @smizell 