### PR TITLE
Update to minim 0.18 (new serialisation)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Master
+
+- Compatibility with Minim 0.18 and minim-api-description 0.5.
+
 # 0.6.1 - 2017-06-29
 
 - We don't try to re-define `sourceMapValue` on an Element when

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Master
+# 0.7.0
 
 - Compatibility with Minim 0.18 and minim-api-description 0.5.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minim-parse-result",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "Minim Parse Result Namespace",
   "main": "./lib/parse-result.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -17,12 +17,12 @@
   },
   "dependencies": {
     "babel-runtime": "^6.23.0",
-    "minim-api-description": "^0.4.1"
+    "minim-api-description": "^0.5.0"
   },
   "devDependencies": {
     "babel-plugin-array-includes": "^2.0.3",
     "chai": "^3.2.0",
-    "minim": "^0.17.1",
+    "minim": "^0.18.0",
     "peasant": "^1.1.0"
   },
   "engines": {

--- a/test/parse-result.js
+++ b/test/parse-result.js
@@ -52,21 +52,45 @@ describe('Parse result namespace', () => {
           {
             element: 'annotation',
             meta: {
-              classes: ['warning'],
+              classes: {
+                element: 'array',
+                content: [
+                  {
+                    element: 'string',
+                    content: 'warning',
+                  },
+                ],
+              },
             },
             content: [],
           },
           {
             element: 'annotation',
             meta: {
-              classes: ['error'],
+              classes: {
+                element: 'array',
+                content: [
+                  {
+                    element: 'string',
+                    content: 'error',
+                  },
+                ],
+              },
             },
             content: [],
           },
           {
             element: 'category',
             meta: {
-              classes: ['api'],
+              classes: {
+                element: 'array',
+                content: [
+                  {
+                    element: 'string',
+                    content: 'api',
+                  },
+                ],
+              },
             },
             content: [],
           },
@@ -125,7 +149,10 @@ describe('Parse result namespace', () => {
       refracted = {
         element: 'annotation',
         attributes: {
-          code: 123,
+          code: {
+            element: 'number',
+            content: 123,
+          },
         },
         content: 'Missing argument description',
       };
@@ -179,12 +206,29 @@ describe('Parse result namespace', () => {
       refracted = {
         element: 'string',
         attributes: {
-          sourceMap: [
-            {
-              element: 'sourceMap',
-              content: [[1, 2]],
-            },
-          ],
+          sourceMap: {
+            element: 'array',
+            content: [
+              {
+                element: 'sourceMap',
+                content: [
+                  {
+                    element: 'array',
+                    content: [
+                      {
+                        element: 'number',
+                        content: 1,
+                      },
+                      {
+                        element: 'number',
+                        content: 2,
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
         },
         content: '',
       };
@@ -209,23 +253,6 @@ describe('Parse result namespace', () => {
 
     it('should have a convenience method for retrieving source map', () => {
       expect(element.sourceMapValue).to.deep.equal([[1, 2]]);
-    });
-
-    it('should serialize with a sourceMap attribute', () => {
-      const expected = {
-        element: 'string',
-        attributes: {
-          sourceMap: [
-            {
-              element: 'sourceMap',
-              content: [[1, 2]],
-            },
-          ],
-        },
-        content: '',
-      };
-
-      expect(namespace.toRefract(element)).to.deep.equal(expected);
     });
   });
 


### PR DESCRIPTION
This updates minim/minim-api-description which follows Refract 1.0 serialisation rules and API Elements 1.0.

## Dependencies

- [x] https://github.com/refractproject/minim/pull/127
- [x] https://github.com/refractproject/minim-api-description/pull/30