### PR TITLE
Support minim 0.19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.8.0
+
+- Add support for minim 0.19 and minim-api-description 0.6.
+
 # 0.7.0
 
 - Compatibility with Minim 0.18 and minim-api-description 0.5.

--- a/package.json
+++ b/package.json
@@ -17,12 +17,12 @@
   },
   "dependencies": {
     "babel-runtime": "^6.23.0",
-    "minim-api-description": "^0.5.0"
+    "minim-api-description": "^0.6.0"
   },
   "devDependencies": {
     "babel-plugin-array-includes": "^2.0.3",
     "chai": "^3.2.0",
-    "minim": "^0.18.0",
+    "minim": "^0.19.0",
     "peasant": "^1.1.0"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minim-parse-result",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Minim Parse Result Namespace",
   "main": "./lib/parse-result.js",
   "repository": {

--- a/src/parse-result.js
+++ b/src/parse-result.js
@@ -22,7 +22,7 @@ export function namespace(options) {
     }
 
     get api() {
-      return this.children.filter(item => item.classes.contains('api')).first();
+      return this.children.filter(item => item.classes.contains('api')).first;
     }
 
     get annotations() {
@@ -77,7 +77,7 @@ export function namespace(options) {
         const sourceMap = this.attributes.get('sourceMap');
 
         if (sourceMap) {
-          return sourceMap.first().toValue();
+          return sourceMap.first.toValue();
         }
 
         return undefined;

--- a/test/parse-result.js
+++ b/test/parse-result.js
@@ -248,7 +248,7 @@ describe('Parse result namespace', () => {
     });
 
     it('should have the source map location', () => {
-      expect(sourceMaps.first().toValue()).to.deep.equal([[1, 2]]);
+      expect(sourceMaps.first.toValue()).to.deep.equal([[1, 2]]);
     });
 
     it('should have a convenience method for retrieving source map', () => {


### PR DESCRIPTION
This pull request updates to support Minim 0.19 (which is not yet released). Pull request is ready for when Minim 0.19 is released and CI can be re-triggered to make it green.

### Dependencies

- [ ] https://github.com/refractproject/minim-api-description/pull/33