### PR TITLE
Add `map` and `flatMap` operators to Parse Result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Minim Parse Result
 
+## Master
+
+### Enhancements
+
+- Adds a `map` and `flatMap` operator to ParseResult.
+
 ## 0.10.1
 
 ### Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Enhancements
 
-- Adds a `map` and `flatMap` operator to ParseResult.
+- Adds a `mapElement` and `flatMapElement` operator to ParseResult.
 
 ## 0.10.1
 

--- a/src/parse-result.js
+++ b/src/parse-result.js
@@ -40,6 +40,51 @@ export function namespace(options) {
     }
 
     /**
+     * @callback mapCallback
+     * @param {Element} element
+     */
+
+    /** Returns a new ParseResult by mapping non-annotation values using `transform`.
+     * @param {mapCallback} transform
+     * @param thisArg
+     * @returns array
+     * @memberof ParseResult.prototype
+     */
+    map(transform, thisArg) {
+      return new ParseResult(super.map((element) => {
+        if (element.element === 'annotation') {
+          return element;
+        }
+
+        return transform(element);
+      }, thisArg));
+    }
+
+    /**
+     * @callback flatMapCallback
+     * @param {Element} element
+     * @returns {ParseResult}
+     */
+
+    /** Returns the result of applying `transform` to non-annotation values, flattening the result.
+     * @param {flatMapCallback} transform
+     * @param thisArg
+     * @returns {ParseResult}
+     * @memberof ParseResult.prototype
+     */
+    flatMap(transform, thisArg) {
+      return this.reduce((result, element) => {
+        if (element.element === 'annotation') {
+          result.push(element);
+        } else {
+          transform.bind(thisArg, element).call().forEach(item => result.push(item));
+        }
+
+        return result;
+      }, new ParseResult());
+    }
+
+    /**
      * @name annotations
      * @type ArraySlice
      * @memberof ParseResult.prototype

--- a/src/parse-result.js
+++ b/src/parse-result.js
@@ -40,17 +40,17 @@ export function namespace(options) {
     }
 
     /**
-     * @callback mapCallback
+     * @callback mapElementCallback
      * @param {Element} element
      */
 
-    /** Returns a new ParseResult by mapping non-annotation values using `transform`.
-     * @param {mapCallback} transform
+    /** Returns a new ParseResult by transforming non-annotation values using `transform`.
+     * @param {mapElementCallback} transform
      * @param thisArg
      * @returns array
      * @memberof ParseResult.prototype
      */
-    map(transform, thisArg) {
+    mapElement(transform, thisArg) {
       return new ParseResult(super.map((element) => {
         if (element.element === 'annotation') {
           return element;
@@ -61,18 +61,18 @@ export function namespace(options) {
     }
 
     /**
-     * @callback flatMapCallback
+     * @callback flatMapElementCallback
      * @param {Element} element
      * @returns {ParseResult}
      */
 
     /** Returns the result of applying `transform` to non-annotation values, flattening the result.
-     * @param {flatMapCallback} transform
+     * @param {flatMapElementCallback} transform
      * @param thisArg
      * @returns {ParseResult}
      * @memberof ParseResult.prototype
      */
-    flatMap(transform, thisArg) {
+    flatMapElement(transform, thisArg) {
       return this.reduce((result, element) => {
         if (element.element === 'annotation') {
           result.push(element);

--- a/test/parse-result.js
+++ b/test/parse-result.js
@@ -12,6 +12,7 @@ import minimParseResult from '../src/parse-result';
 const namespace = minim.namespace()
   .use(minimParseResult);
 
+const ParseResult = namespace.getElementClass('parseResult');
 const Annotation = namespace.getElementClass('annotation');
 const Category = namespace.getElementClass('category');
 
@@ -134,6 +135,43 @@ describe('Parse result namespace', () => {
       items.forEach((item) => {
         expect(item).to.be.an.instanceof(Annotation);
         expect(item).to.have.class('error');
+      });
+    });
+
+    describe('#map', () => {
+      it('transforms the parse result content', () => {
+        parseResult = new ParseResult([1, 2]);
+
+        const result = parseResult.map(element => element.toValue() * 2);
+        expect(result.toValue()).to.deep.equal([2, 4]);
+      });
+
+      it('does not transform annotation elements', () => {
+        const annotation = new Annotation();
+        parseResult = new ParseResult([annotation]);
+
+        const result = parseResult.map(() => null);
+        expect(result).to.deep.equal(parseResult);
+      });
+    });
+
+    describe('#flatMap', () => {
+      it('transforms the parse result content', () => {
+        const result = new ParseResult([1, 2])
+          .flatMap(number =>
+            new ParseResult([
+              number.toValue() * 2,
+              number.toValue() * 4,
+            ]))
+          .toValue();
+
+        expect(result).to.deep.equal([2, 4, 4, 8]);
+      });
+
+      it('does not transform annotation elements', () => {
+        parseResult = new ParseResult([new Annotation()]);
+        const result = parseResult.flatMap(() => new ParseResult([1, 2]));
+        expect(result).not.to.equal(parseResult);
       });
     });
   });

--- a/test/parse-result.js
+++ b/test/parse-result.js
@@ -138,11 +138,11 @@ describe('Parse result namespace', () => {
       });
     });
 
-    describe('#map', () => {
+    describe('#mapElement', () => {
       it('transforms the parse result content', () => {
         parseResult = new ParseResult([1, 2]);
 
-        const result = parseResult.map(element => element.toValue() * 2);
+        const result = parseResult.mapElement(element => element.toValue() * 2);
         expect(result.toValue()).to.deep.equal([2, 4]);
       });
 
@@ -150,15 +150,15 @@ describe('Parse result namespace', () => {
         const annotation = new Annotation();
         parseResult = new ParseResult([annotation]);
 
-        const result = parseResult.map(() => null);
+        const result = parseResult.mapElement(() => null);
         expect(result).to.deep.equal(parseResult);
       });
     });
 
-    describe('#flatMap', () => {
+    describe('#flatMapElement', () => {
       it('transforms the parse result content', () => {
         const result = new ParseResult([1, 2])
-          .flatMap(number =>
+          .flatMapElement(number =>
             new ParseResult([
               number.toValue() * 2,
               number.toValue() * 4,
@@ -170,7 +170,7 @@ describe('Parse result namespace', () => {
 
       it('does not transform annotation elements', () => {
         parseResult = new ParseResult([new Annotation()]);
-        const result = parseResult.flatMap(() => new ParseResult([1, 2]));
+        const result = parseResult.flatMapElement(() => new ParseResult([1, 2]));
         expect(result).not.to.equal(parseResult);
       });
     });


### PR DESCRIPTION
I would like to be able to `map` and "flatten-map" the values in a parse result. Since an `annotation` is not a value, it is additional metadata, like an error or warning and thus I do not want it to be included in the `map` of a result type.

I am not sure how familiar my reviewer is with high order functions like `map` and `flatMap` so I will demonstrate by example. These concepts are generic functional programming and thus I will show how they are elsewhere in the "real world".

This would be pretty similiar conceptually to how the `Optional` type in Swift works, an Optional is an "either" value for a type or no value. For example `Optional<Int>` may optionally contain a number. If you run `map` on it, then it would transform the value when present, if it is an empty value then the transformation is not done. `value.map { $0 * 2}` for example on `Optional<Int>` where it contains the value `2` would return a type of `Optional<Int>` where the value is `4`.

Similiary, the `flatMap` method on `Optional` type is used for transforming a value, but the result itself can be optional. For example, if I were to use `map` on an optional string type to transform the string into an integer:

```swift
value.map { Int($0) }
```

Then, the result would be `Optional<Optional<String>>`, we would use `flatMap` instead to "flatten" the result.

```swift
value.flatMap { Int($0) }
```

| Value   | Transform Closure Ran       | Result |
|---------|-----------------------------|--------|
| None    | No                          | None   |
| "five"  | Yes (returns none type)     | None   |
| "5"     | Yes (returns none 5 as int) | 5      |

A closer example would the the "Result type" (https://github.com/antitypical/Result/) which represents an either of a value or an error. `map` on a result type, would transform the value if there was a value or return the error. For example:

```swift
let result = Result(2)
result.map { $0 * 2 }
// Result<Int> with value `4`

let result = Result<Int>(Error(...))
result.map { $0 * 2 }
// Result<Int> with no value (error)
// map transform closure not ran
```

Similiary, using `Result.flatMap`, the transformation itself returns another result:

```swift
let result = Result(2)
result.flatMap { Result<Int>(Error(...) }
// Result<Int> with error
```